### PR TITLE
fix for errors when deploying a new application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .gradle/
 build/
 .idea/
-*.iml
+**.iml
+*.ipr
+*.iws
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'groovy'
 apply from: rootProject.file('gradle/deploy.gradle')
 
-version = '0.5.13'
+version = '0.5.14'
 group = 'com.wikia.gradle'
 sourceCompatibility = 1.7
 

--- a/src/main/groovy/com/wikia/gradle/marathon/ConfirmationTask.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/ConfirmationTask.groovy
@@ -10,8 +10,7 @@ class ConfirmationTask extends DefaultTask {
     def confirmation() {
         def console = System.console()
         if (console != null) {
-            println "CONFIRMATION: type project name (" + project.name + ")";
-            def line = console.readLine();
+            def line = console.readLine("\nCONFIRMATION: type project name (" + project.name + ")");
             if (!(line == project.name)) {
                 throw new BuildCancelledException("aborted by user")
             }

--- a/src/main/groovy/com/wikia/gradle/marathon/MarathonTask.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/MarathonTask.groovy
@@ -52,7 +52,7 @@ class MarathonTask extends DefaultTask {
         return app
     }
 
-    static Optional<App> attemptGetExistingApp(Marathon client, String appId) {
+    def Optional<App> attemptGetExistingApp(Marathon client, String appId) {
         def app
         try {
             app = Optional.<App> of(client.getApp(appId).getApp())


### PR DESCRIPTION
@Wikia/services-team @pchojnacki 

Seeing this error when trying to deploy a non-existant app:

```
Execution failed for task ':service:user-preference:deployDev'.
> No signature of method: static com.wikia.gradle.marathon.MarathonTask.getLogger() is applicable for argument types: () values: []
  Possible solutions: getLogger(), getLogging(), getStage(), getName(), getState()
```

This was because `attemptGetExistingApp` was declared static, but used the `Task` non-static method `getLogger`