### PR TITLE
print better error message and bump version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'groovy'
 apply from: rootProject.file('gradle/deploy.gradle')
 
-version = '0.5.14'
+version = '0.5.15'
 group = 'com.wikia.gradle'
 sourceCompatibility = 1.7
 

--- a/src/main/groovy/com/wikia/gradle/marathon/ConfirmationTask.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/ConfirmationTask.groovy
@@ -10,7 +10,7 @@ class ConfirmationTask extends DefaultTask {
     def confirmation() {
         def console = System.console()
         if (console != null) {
-            def line = console.readLine("\nCONFIRMATION: type project name (" + project.name + ")");
+            def line = console.readLine("\nCONFIRMATION: type project name (" + project.name + "): ");
             if (!(line == project.name)) {
                 throw new BuildCancelledException("aborted by user")
             }


### PR DESCRIPTION
@Wikia/services-team 
https://wikia-inc.atlassian.net/browse/SERVICES-679

Specifically catching the error thrown when an existing deployment is in progress (see [docs](https://mesosphere.github.io/marathon/docs/rest-api.html#put-v2-apps-appid)). Unfortunately we can't inspect the exception object as it currently is implemented. We could either replace the error handling by effectively rewriting `MarathonClient.getInstance`, or we could check the error's message directly. I chose the simpler approach, but if we need to get fancier with error handling we can do that in the future. For now, the error without `--stacktrace` will show as 

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':service:deployment-exceptions-test:deployDev'.
> cannot deploy, existing deployment already in progress

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```

and with `--stacktrace` will show as

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':service:deployment-exceptions-test:deployDev'.
> cannot deploy, existing deployment already in progress

* Try:
Run with --info or --debug option to get more log output.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':service:deployment-exceptions-test:deployDev'.
	... // hella stuff
Caused by: java.lang.RuntimeException: cannot deploy, existing deployment already in progress
	at com.wikia.gradle.marathon.MarathonTask.handleUpdateException(MarathonTask.groovy:113)
	at com.wikia.gradle.marathon.MarathonTask$handleUpdateException$1.callCurrent(Unknown Source)
	at com.wikia.gradle.marathon.MarathonTask.setupApp(MarathonTask.groovy:96)
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:75)
	at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.doExecute(AnnotationProcessingTaskFactory.java:226)
	at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.execute(AnnotationProcessingTaskFactory.java:219)
	at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.execute(AnnotationProcessingTaskFactory.java:208)
	at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:585)
	at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:568)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:80)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:61)
	... 61 more


BUILD FAILED
```

In either case, the message `cannot deploy, existing deployment already in progress` will be present.