### PR TITLE
[SERVICES-1182] Support for marathon deploy to staging env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+# Usage #
+
+## Buidling ##
+```bash
+gradle build
+```
+
+## Testing ##
+```bash
+gradle test
+```
+
+## Publishing ##
+```
+gradle publish
+```
+
 ### Project properties that change behaviour
 
 - marathon.forceUpdate - makes app update override any deployments currently running

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'groovy'
 apply from: rootProject.file('gradle/deploy.gradle')
 
-version = '0.5.27'
+version = '0.5.28'
 group = 'com.wikia.gradle'
 sourceCompatibility = 1.7
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'groovy'
 apply from: rootProject.file('gradle/deploy.gradle')
 
-version = '0.5.24'
+version = '0.5.27'
 group = 'com.wikia.gradle'
 sourceCompatibility = 1.7
 
@@ -9,7 +9,7 @@ repositories {
     mavenCentral()
     mavenLocal()
     maven { url "http://repo.jenkins-ci.org/repo" }
-    maven { url "${archivaUrl}/repository/internal" }
+    maven { url "${artifactoryUrl}/artifactory/plugins-source" }
 }
 
 dependencies {
@@ -22,7 +22,7 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'com.github.zafarkhaja:java-semver:0.8.0'
     compile 'org.kohsuke:github-api:1.59'
-    compile 'com.wikia:marathon-client:0.5.1'
+    compile 'com.wikia:marathon-client:0.5.3'
 
     compile "org.eclipse.aether:aether-api:${aetherVersion}"
     compile "org.eclipse.aether:aether-impl:${aetherVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'groovy'
 apply from: rootProject.file('gradle/deploy.gradle')
 
-version = '0.5.23'
+version = '0.5.24'
 group = 'com.wikia.gradle'
 sourceCompatibility = 1.7
 

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -18,13 +18,13 @@ publishing {
     repositories {
         maven {
             credentials {
-                username archivaUsername
-                password archivaPassword
+                username artifactoryUsername
+                password artifactoryPassword
             }
             if (project.version.endsWith('-SNAPSHOT')) {
-                url "${archivaUrl}/repository/snapshots"
+                url "${artifactoryUrl}/artifactory/libs-snapshot-local"
             } else {
-                url "${archivaUrl}/repository/internal"
+                url "${artifactoryUrl}/artifactory/plugins-source"
             }
         }
     }

--- a/src/main/groovy/com/wikia/gradle/marathon/common/Marathon.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/common/Marathon.groovy
@@ -10,8 +10,10 @@ import static com.wikia.gradle.marathon.common.ConfigResolver.resolveNullConfig
 class Marathon implements Validating {
 
     String prodUrl
+    String stagingUrl
     String devUrl
     Boolean useProd
+    Boolean useStaging
     Closure rawUpgradeStrategy
     Closure rawLabels
     Double backoffFactor
@@ -20,11 +22,15 @@ class Marathon implements Validating {
 
     def validate() {
         if (this.properties.get("prodUrl") == null) {
-            throw new RuntimeException("Marathon.devUrl needs to be set")
+            throw new RuntimeException("Marathon.prodUrl needs to be set")
+        }
+
+        if (this.properties.get("stagingUrl") == null) {
+            throw new RuntimeException("Marathon.stagingUrl needs to be set")
         }
 
         if (this.properties.get("devUrl") == null) {
-            throw new RuntimeException("Marathon.prodUrl needs to be set")
+            throw new RuntimeException("Marathon.devUrl needs to be set")
         }
     }
 
@@ -55,6 +61,8 @@ class Marathon implements Validating {
     def getUrl() {
         if (useProd) {
             return prodUrl
+        } else if (useStaging) {
+            return stagingUrl
         } else {
             return devUrl
         }

--- a/src/main/groovy/com/wikia/gradle/marathon/common/Marathon.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/common/Marathon.groovy
@@ -9,9 +9,7 @@ import static com.wikia.gradle.marathon.common.ConfigResolver.resolveNullConfig
 @AutoClone
 class Marathon implements Validating {
 
-    String prodUrl
-    String stagingUrl
-    String devUrl
+    String marathonUrl
     Boolean useProd
     Boolean useStaging
     Closure rawUpgradeStrategy
@@ -21,16 +19,8 @@ class Marathon implements Validating {
     Integer maxLaunchDelaySeconds
 
     def validate() {
-        if (this.properties.get("prodUrl") == null) {
-            throw new RuntimeException("Marathon.prodUrl needs to be set")
-        }
-
-        if (this.properties.get("stagingUrl") == null) {
-            throw new RuntimeException("Marathon.stagingUrl needs to be set")
-        }
-
-        if (this.properties.get("devUrl") == null) {
-            throw new RuntimeException("Marathon.devUrl needs to be set")
+        if (this.properties.get("marathonUrl") == null) {
+            throw new RuntimeException("Marathon.marathonUrl needs to be set")
         }
     }
 
@@ -59,12 +49,6 @@ class Marathon implements Validating {
     }
 
     def getUrl() {
-        if (useProd) {
-            return prodUrl
-        } else if (useStaging) {
-            return stagingUrl
-        } else {
-            return devUrl
-        }
+        return marathonUrl
     }
 }

--- a/src/main/groovy/com/wikia/gradle/marathon/common/Marathon.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/common/Marathon.groovy
@@ -10,8 +10,6 @@ import static com.wikia.gradle.marathon.common.ConfigResolver.resolveNullConfig
 class Marathon implements Validating {
 
     String marathonUrl
-    Boolean useProd
-    Boolean useStaging
     Closure rawUpgradeStrategy
     Closure rawLabels
     Double backoffFactor

--- a/src/test/groovy/com/wikia/gradle/marathon/common/MarathonExtensionTest.groovy
+++ b/src/test/groovy/com/wikia/gradle/marathon/common/MarathonExtensionTest.groovy
@@ -13,9 +13,7 @@ class MarathonExtensionTest {
         def stageCreator = new MarathonExtension()
         stageCreator.globalDefaults {
             marathon {
-                prodUrl = "ehlo"
-                stagingUrl = "lohe"
-                devUrl = "olhe"
+                marathonUrl = "ehlo"
                 backoffFactor = 1.1
                 backoffSeconds = 1
                 maxLaunchDelaySeconds = 10
@@ -77,13 +75,11 @@ class MarathonExtensionTest {
     }
 
     @Test
-    void "Stages Config Can Be Inherited From Base Using Dev Marathon Address"() {
+    void "Stages Config Can Be Inherited From Base Using Marathon Address"() {
         def stageCreator = new MarathonExtension()
         stageCreator.globalDefaults {
             marathon {
-                prodUrl = "A"
-                stagingUrl = "S"
-                devUrl = "V"
+                marathonUrl = "U"
             }
         }
 
@@ -97,32 +93,7 @@ class MarathonExtensionTest {
 
         assertNull(rawStage.resolve(Marathon).url)
         assertEquals("x", stage.name)
-        assertEquals("V", stage.resolve(Marathon).url)
-    }
-    @Test
-    void "Stages Config Can Be Inherited From Base Using Prod Marathon Address"() {
-        def stageCreator = new MarathonExtension()
-        stageCreator.globalDefaults {
-            marathon {
-                prodUrl = "A"
-                stagingUrl = "S"
-                devUrl = "V"
-            }
-        }
-
-        Stage rawStage = stageCreator.anyRandomStage {
-            name = "x"
-        }
-
-        def stage = stageCreator.getStage("x")
-        stage.marathon {
-            useProd = true
-        }
-
-        assertNull(rawStage.resolve(Marathon).url)
-        assertEquals("x", stage.name)
-        assertEquals("A", stage.resolve(Marathon).url)
-        assertEquals("{}", stage.resolve(Marathon).resolveUpgradeStrategy().toString())
+        assertEquals("U", stage.resolve(Marathon).url)
     }
 
     @Test
@@ -131,7 +102,7 @@ class MarathonExtensionTest {
         def dsl = {
             globalDefaults {
                 marathon {
-                    prodUrl = "http://"
+                    marathonUrl = "http://"
                     upgradeStrategy {
                         minimumHealthCapacity = 1
                         maximumOverCapacity = 0

--- a/src/test/groovy/com/wikia/gradle/marathon/common/MarathonExtensionTest.groovy
+++ b/src/test/groovy/com/wikia/gradle/marathon/common/MarathonExtensionTest.groovy
@@ -14,6 +14,7 @@ class MarathonExtensionTest {
         stageCreator.globalDefaults {
             marathon {
                 prodUrl = "ehlo"
+                stagingUrl = "lohe"
                 devUrl = "olhe"
                 backoffFactor = 1.1
                 backoffSeconds = 1
@@ -81,6 +82,7 @@ class MarathonExtensionTest {
         stageCreator.globalDefaults {
             marathon {
                 prodUrl = "A"
+                stagingUrl = "S"
                 devUrl = "V"
             }
         }
@@ -103,6 +105,7 @@ class MarathonExtensionTest {
         stageCreator.globalDefaults {
             marathon {
                 prodUrl = "A"
+                stagingUrl = "S"
                 devUrl = "V"
             }
         }


### PR DESCRIPTION
This introduce possibility to deploy to marathon on staging environment, considering that proper `marathonUrl` is provided in configuration. 

I've extended it with additional flag for now, but for sure it would be nice to make it in more general way, maybe using already declared task name or environment value.

Related to : https://github.com/Wikia/marathon-client/pull/6

/cc @pchojnacki @Wikia/services-team 