### PR TITLE
Added support for Marathon Constraints.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'groovy'
 apply from: rootProject.file('gradle/deploy.gradle')
 
-version = '0.5.28'
+version = '0.5.29'
 group = 'com.wikia.gradle'
 sourceCompatibility = 1.7
 

--- a/src/main/groovy/com/wikia/gradle/marathon/MarathonTask.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/MarathonTask.groovy
@@ -1,4 +1,6 @@
 package com.wikia.gradle.marathon
+
+import com.wikia.gradle.marathon.common.Constraints
 import com.wikia.gradle.marathon.common.Environment
 import com.wikia.gradle.marathon.common.Healthchecks
 import com.wikia.gradle.marathon.common.Resources
@@ -45,6 +47,12 @@ class MarathonTask extends DefaultTask {
 
         if (healthChecks.size() > 0) {
             app.setHealthChecks(healthChecks)
+        }
+
+        List<List<String>> constraints = this.stage.resolve(Constraints).getConstraints()
+
+        if (constraints.size() > 0) {
+            app.setConstraints(constraints)
         }
 
         def appConfig = this.stage.resolve(com.wikia.gradle.marathon.common.App)

--- a/src/main/groovy/com/wikia/gradle/marathon/MarathonTask.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/MarathonTask.groovy
@@ -44,16 +44,10 @@ class MarathonTask extends DefaultTask {
         app.setMaxLaunchDelaySeconds(marathon.maxLaunchDelaySeconds)
 
         List<HealthCheck> healthChecks = this.stage.resolve(Healthchecks).healthchecksProvider()
-
-        if (healthChecks.size() > 0) {
-            app.setHealthChecks(healthChecks)
-        }
+        app.setHealthChecks(healthChecks)
 
         List<List<String>> constraints = this.stage.resolve(Constraints).getConstraints()
-
-        if (constraints.size() > 0) {
-            app.setConstraints(constraints)
-        }
+        app.setConstraints(constraints)
 
         def appConfig = this.stage.resolve(com.wikia.gradle.marathon.common.App)
         appConfig.validate()

--- a/src/main/groovy/com/wikia/gradle/marathon/common/Constraints.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/common/Constraints.groovy
@@ -1,0 +1,30 @@
+package com.wikia.gradle.marathon.common
+
+class Constraints implements Validating {
+    List<List<String>> constraintList = new LinkedList<>()
+
+    def constraint(String attribute, String operator, String value) {
+        List<String> constraints = new ArrayList<>()
+        constraints.add(attribute)
+        constraints.add(operator)
+        constraints.add(value)
+        constraintList.add(constraints)
+    }
+
+    def constraint(String attribute, String operator) {
+        List<String> constraints = new ArrayList<>()
+        constraints.add(attribute)
+        constraints.add(operator)
+        constraintList.add(constraints)
+    }
+
+    public def List<List<String>> getConstraints() {
+        List<List<String>> ret = new ArrayList<>()
+
+        constraintList.each { list ->
+            ret.add(new ArrayList<String>(list))
+        }
+
+        return ret
+    }
+}

--- a/src/main/groovy/com/wikia/gradle/marathon/common/Marathon.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/common/Marathon.groovy
@@ -12,6 +12,7 @@ class Marathon implements Validating {
     String marathonUrl
     Closure rawUpgradeStrategy
     Closure rawLabels
+    Closure rawConstraints
     Double backoffFactor
     Integer backoffSeconds
     Integer maxLaunchDelaySeconds
@@ -44,6 +45,18 @@ class Marathon implements Validating {
 
     Labels resolveLabels() {
         return resolveNullConfig(this.rawLabels, Labels)
+    }
+
+    def constraints(Closure constraints) {
+        setConstraints(constraints)
+    }
+
+    def setConstraints(Closure constraints) {
+        this.rawConstraints = dslToParamClosure(constraints)
+    }
+
+    Constraints resolveConstraints() {
+        return resolveNullConfig(this.rawConstraints, Constraints)
     }
 
     def getUrl() {

--- a/src/main/groovy/com/wikia/gradle/marathon/common/Stage.groovy
+++ b/src/main/groovy/com/wikia/gradle/marathon/common/Stage.groovy
@@ -40,6 +40,12 @@ class Stage {
         ))
     }
 
+    def constraints(Closure dsl) {
+        closures.put(Constraints, stackClosures(
+                dslToParamClosure(dsl), closures.get(Constraints)
+        ))
+    }
+
     def validate() {
         if (this.name == null) {
             throw new RuntimeException("Stage.name needs to be set")

--- a/src/test/groovy/com/wikia/gradle/marathon/common/ConstraintsDslTest.groovy
+++ b/src/test/groovy/com/wikia/gradle/marathon/common/ConstraintsDslTest.groovy
@@ -1,0 +1,25 @@
+package com.wikia.gradle.marathon.common
+
+import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+
+class ConstraintsDslTest {
+
+    @Test
+    public void dslCreatesProperConstraintsConfiguration() {
+        def constraints = new Constraints()
+        Closure dsl = {
+            constraint("hostname", "GROUP_BY")
+            constraint("hostname", "UNIQUE")
+            constraint("rack_id", "GROUP_BY", "3")
+        }
+        dsl.delegate = constraints
+        dsl()
+        def result = constraints.getConstraints()
+        assertEquals(3, result.size())
+        assertEquals(["hostname", "GROUP_BY"], result[0])
+        assertEquals(["hostname", "UNIQUE"], result[1])
+        assertEquals(["rack_id", "GROUP_BY", "3"], result[2])
+    }
+}


### PR DESCRIPTION
This allows us to specify the constraints for given Marathon task.

@pchojnacki I didn't found a way for groovy to properly delegate list of closures like this `["item1", "item2", "item3"]` to a class. Any ideas if we can achieve this in some more useful DSL?